### PR TITLE
Added missing return to input(int)

### DIFF
--- a/src/JetsonGPIO.cpp
+++ b/src/JetsonGPIO.cpp
@@ -557,7 +557,7 @@ int GPIO::input(const string& channel){
 }
 
 int GPIO::input(int channel){
-    input(to_string(channel));
+    return input(to_string(channel));
 }
 
 


### PR DESCRIPTION
The function input(int pin) that just casts the pin to a string and calls input(string pin) was missing a return, so it was returning garbage values instead. With return it works perfectly