### PR TITLE
Added error printouts for system calls.

### DIFF
--- a/src/gpio_event.cpp
+++ b/src/gpio_event.cpp
@@ -154,6 +154,7 @@ int _open_sysfd_value(int gpio, int& fd)
     fd = open(buf.c_str(), O_RDONLY);
 
     if (fd == -1) {
+        std::perror("sysfs/value open");
         return (int)GPIO::EventResultCode::SysFD_ValueOpen;
     }
 

--- a/src/gpio_event.cpp
+++ b/src/gpio_event.cpp
@@ -105,6 +105,7 @@ int _write_sysfs_edge(int gpio, Edge edge, bool allow_none = true)
     int edge_fd = open(buf.c_str(), O_WRONLY);
     if (edge_fd == -1) {
         // I/O Error
+        std::perror("sysfs/edge open");
         return (int)GPIO::EventResultCode::SysFD_EdgeOpen;
     }
 


### PR DESCRIPTION
added two missed perror() calls in error exceptions in the case where open() is invoked.

May assist in the case of #28 