### PR TITLE
Change channel type in event module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,22 @@ The second parameter specifies the edge to be detected and can be GPIO::RISING, 
 ```cpp
 // timeout is in milliseconds__
 // debounce_time set to 10ms
-GPIO::wait_for_edge(channel, GPIO::RISING, 10, 500);
+GPIO::WaitResult result = GPIO::wait_for_edge(channel, GPIO::RISING, 10, 500);
+```
+The function returns a `GPIO::WaitResult` object that contains the channel name for which the edge was detected. 
+
+To check if the event was detected or a timeout occurred, you can use `.is_event_detected()` method of the returned object or just simply cast it to `bool` type:
+```cpp
+// returns the channel name for which the edge was detected ("None" if a timeout occurred)
+std::string eventDetectedChannel = result.channel();
+
+if(result.is_event_detected()){ /*...*/ }
+// or 
+if(result){ /*...*/ } // is equal to if(result.is_event_detected())
 ```
 
-The function returns the channel for which the edge was detected. 
-If a timeout occurred, it returns 0(if the channel is int) or an empty string(if the channel is string).
+
+
 
 
 __The event_detected() function__

--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ The second parameter specifies the edge to be detected and can be GPIO::RISING, 
 GPIO::wait_for_edge(channel, GPIO::RISING, 10, 500);
 ```
 
-The function returns the channel for which the edge was detected or 0 if a timeout occurred.
+The function returns the channel for which the edge was detected. 
+If a timeout occurred, it returns 0(if the channel is int) or an empty string(if the channel is string).
 
 
 __The event_detected() function__
@@ -272,7 +273,7 @@ GPIO::add_event_detect(channel, GPIO::RISING, callback_fn);
 
 Any object that satisfies the following requirements can be used as callback functions. 
 
-- Callable (argument type: int, return type: void)
+- Callable (argument type: const std::string&, return type: void)
 - Copy-constructible 
 - Equality-comparable with same type (ex> func0 == func1)  
 
@@ -286,7 +287,7 @@ public:
     MyCallback(const std::string& name) : name(name) {}
     MyCallback(const MyCallback&) = default; // Copy-constructible
 
-    void operator()(int channel) // Callable
+    void operator()(const std::string& channel) // Callable
     {
         std::cout << "A callback named " << name;
         std::cout << " called from channel " << channel << std::endl;

--- a/include/JetsonGPIO.h
+++ b/include/JetsonGPIO.h
@@ -200,6 +200,24 @@ namespace GPIO
       std::function<bool(const func_t&, const func_t&)> comparer;
    };
 
+
+   class WaitResult
+   {
+   public:
+      WaitResult(const std::string& channel);
+      WaitResult(const WaitResult&);
+      WaitResult(WaitResult&&);
+      WaitResult& operator=(const WaitResult&);
+      WaitResult& operator=(WaitResult&&);
+
+      inline const std::string& channel() const { return _channel; }
+      bool is_event_detected() const;
+      inline operator bool() const { return is_event_detected(); }
+
+   private:
+      std::string _channel;
+   };
+
    //----------------------------------
 
    /* Function used to check if an event occurred on the specified channel.
@@ -236,9 +254,9 @@ namespace GPIO
       @edge must be a member of GPIO::Edge
       @bouncetime in milliseconds (optional)
       @timeout in milliseconds (optional)
-      @returns channel for an event, 0 for a timeout */
-   std::string wait_for_edge(const std::string& channel, Edge edge, unsigned long bounce_time = 0, unsigned long timeout = 0);
-   int wait_for_edge(int channel, Edge edge, unsigned long bounce_time = 0, unsigned long timeout = 0);
+      @returns WaitResult object*/
+   WaitResult wait_for_edge(const std::string& channel, Edge edge, unsigned long bounce_time = 0, unsigned long timeout = 0);
+   WaitResult wait_for_edge(int channel, Edge edge, unsigned long bounce_time = 0, unsigned long timeout = 0);
 
    //----------------------------------
 

--- a/include/JetsonGPIO.h
+++ b/include/JetsonGPIO.h
@@ -157,6 +157,8 @@ namespace GPIO
    class Callback
    {
    private:
+
+      // To do: replace func_t to std::function<void(const std::string&)>;
       using func_t = std::function<void(int)>;
 
       template <class T> 
@@ -189,6 +191,7 @@ namespace GPIO
       Callback(const Callback&) = default;
       Callback& operator=(const Callback&) = default;
 
+      // To do: fix it to void operator()(const std::string& input) const;
       void operator()(int input) const;
 
       friend bool operator==(const Callback& A, const Callback& B);
@@ -236,6 +239,8 @@ namespace GPIO
       @bouncetime in milliseconds (optional)
       @timeout in milliseconds (optional)
       @returns channel for an event, 0 for a timeout */
+
+   // To do: change the return type to std::string;
    int wait_for_edge(const std::string& channel, Edge edge, unsigned long bounce_time = 0, unsigned long timeout = 0);
    int wait_for_edge(int channel, Edge edge, unsigned long bounce_time = 0, unsigned long timeout = 0);
 

--- a/include/JetsonGPIO.h
+++ b/include/JetsonGPIO.h
@@ -157,9 +157,7 @@ namespace GPIO
    class Callback
    {
    private:
-
-      // To do: replace func_t to std::function<void(const std::string&)>;
-      using func_t = std::function<void(int)>;
+      using func_t = std::function<void(const std::string&)>;
 
       template <class T> 
       static bool comparer_impl(const func_t& A, const func_t& B)
@@ -183,7 +181,7 @@ namespace GPIO
       : function(std::forward<T>(function)),
         comparer([](const func_t& A, const func_t& B) { return comparer_impl<std::decay_t<T>>(A, B); })
       {
-         static_assert(std::is_constructible<func_t, T&&>::value, "Callback return type: void, argument type: int");
+         static_assert(std::is_constructible<func_t, T&&>::value, "Callback return type: void, argument type: const std::string&");
       }
 
       Callback(Callback&&) = default;
@@ -191,8 +189,8 @@ namespace GPIO
       Callback(const Callback&) = default;
       Callback& operator=(const Callback&) = default;
 
-      // To do: fix it to void operator()(const std::string& input) const;
       void operator()(int input) const;
+      void operator()(const std::string& input) const;
 
       friend bool operator==(const Callback& A, const Callback& B);
       friend bool operator!=(const Callback& A, const Callback& B);
@@ -239,9 +237,7 @@ namespace GPIO
       @bouncetime in milliseconds (optional)
       @timeout in milliseconds (optional)
       @returns channel for an event, 0 for a timeout */
-
-   // To do: change the return type to std::string;
-   int wait_for_edge(const std::string& channel, Edge edge, unsigned long bounce_time = 0, unsigned long timeout = 0);
+   std::string wait_for_edge(const std::string& channel, Edge edge, unsigned long bounce_time = 0, unsigned long timeout = 0);
    int wait_for_edge(int channel, Edge edge, unsigned long bounce_time = 0, unsigned long timeout = 0);
 
    //----------------------------------

--- a/include/private/gpio_event.h
+++ b/include/private/gpio_event.h
@@ -53,11 +53,13 @@ enum class EventResultCode {
 
 extern std::map<EventResultCode, const char*> event_error_code_to_message;
 
+// to do: change channel_id to std::string 
 int _blocking_wait_for_edge(int gpio, const std::string& gpio_name, int channel_id, Edge edge, uint64_t bounce_time, uint64_t timeout);
 
 bool _edge_event_detected(int gpio);
 bool _edge_event_exists(int gpio);
 
+// to do: change channel_id to std::string 
 int _add_edge_detect(int gpio, const std::string& gpio_name, int channel_id, Edge edge, uint64_t bounce_time);
 void _remove_edge_detect(int gpio, const std::string& gpio_name);
 

--- a/include/private/gpio_event.h
+++ b/include/private/gpio_event.h
@@ -53,14 +53,13 @@ enum class EventResultCode {
 
 extern std::map<EventResultCode, const char*> event_error_code_to_message;
 
-// to do: change channel_id to std::string 
-int _blocking_wait_for_edge(int gpio, const std::string& gpio_name, int channel_id, Edge edge, uint64_t bounce_time, uint64_t timeout);
+
+int _blocking_wait_for_edge(int gpio, const std::string& gpio_name, const std::string& channel_id, Edge edge, uint64_t bounce_time, uint64_t timeout);
 
 bool _edge_event_detected(int gpio);
 bool _edge_event_exists(int gpio);
 
-// to do: change channel_id to std::string 
-int _add_edge_detect(int gpio, const std::string& gpio_name, int channel_id, Edge edge, uint64_t bounce_time);
+int _add_edge_detect(int gpio, const std::string& gpio_name, const std::string& channel_id, Edge edge, uint64_t bounce_time);
 void _remove_edge_detect(int gpio, const std::string& gpio_name);
 
 int _add_edge_callback(int gpio, const Callback& callback);

--- a/samples/button_interrupt.cpp
+++ b/samples/button_interrupt.cpp
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.
 // for delay function.
 #include <chrono>
 #include <thread>
+#include <string>
 
 // for signal handling
 #include <JetsonGPIO.h>
@@ -45,7 +46,7 @@ inline void delayMs(int ms) { this_thread::sleep_for(chrono::milliseconds(ms)); 
 
 void signalHandler(int s) { end_this_program = true; }
 
-void blink(int channel)
+void blink(const std::string& channel)
 {
     puts("Blink LED 2");
     for (int i = 0; i < 5; ++i) {

--- a/samples/test_all_apis.cpp
+++ b/samples/test_all_apis.cpp
@@ -445,9 +445,10 @@ private:
         GPIO::setup(pin_data.out_a, GPIO::OUT, GPIO::LOW);
         GPIO::setup(pin_data.in_a, GPIO::IN);
         auto dsc = DelayedSetChannel(pin_data.out_a, GPIO::HIGH, 0.5);
-        auto val = GPIO::wait_for_edge(pin_data.in_a, GPIO::RISING, 10, 1000);
+        auto result = GPIO::wait_for_edge(pin_data.in_a, GPIO::RISING, 10, 1000);
         dsc.wait();
-        assert(val == pin_data.in_a);
+        assert(std::stoi(result.channel()) == pin_data.in_a);
+        assert(result.is_event_detected());
         GPIO::cleanup();
     }
 
@@ -458,9 +459,10 @@ private:
         GPIO::setup(pin_data.out_a, GPIO::OUT, GPIO::HIGH);
         GPIO::setup(pin_data.in_a, GPIO::IN);
         auto dsc = DelayedSetChannel(pin_data.out_a, GPIO::LOW, 0.5);
-        auto val = GPIO::wait_for_edge(pin_data.in_a, GPIO::FALLING, 10, 1000);
+        auto result = GPIO::wait_for_edge(pin_data.in_a, GPIO::FALLING, 10, 1000);
         dsc.wait();
-        assert(val == pin_data.in_a);
+        assert(std::stoi(result.channel()) == pin_data.in_a);
+        assert(result.is_event_detected());
         GPIO::cleanup();
     }
 

--- a/samples/test_all_apis.cpp
+++ b/samples/test_all_apis.cpp
@@ -100,7 +100,7 @@ struct TestFunc
 class TestCallback
 {
 public:
-    TestCallback(bool* flag, int target) : flag(flag), target(target){};
+    TestCallback(bool* flag, const std::string& target) : flag(flag), target(target){};
 
     TestCallback(const TestCallback&) = default;
 
@@ -109,7 +109,7 @@ public:
         return other.flag == flag && other.target == target;
     }
 
-    void operator()(int channel)
+    void operator()(const std::string& channel)
     {
         if (channel == target && flag != nullptr)
         {
@@ -119,7 +119,7 @@ public:
 
 private:
     bool* flag;
-    int target;
+    std::string target;
 };
 
 
@@ -727,7 +727,7 @@ private:
         GPIO::setup(pin_data.out_a, GPIO::OUT, init);
         GPIO::setup(pin_data.in_a, GPIO::IN);
 
-        TestCallback callback(&event_callback_occurred, pin_data.in_a);
+        TestCallback callback(&event_callback_occurred, std::to_string(pin_data.in_a));
 
         auto get_saw_event = [&]() mutable -> bool
         {

--- a/src/JetsonGPIO.cpp
+++ b/src/JetsonGPIO.cpp
@@ -659,11 +659,14 @@ void GPIO::remove_event_callback(int channel, const Callback& callback)
 
 void GPIO::add_event_detect(const std::string& channel, Edge edge, const Callback& callback, unsigned long bounce_time)
 {
+   // To do: if the numbering mode is CVM or TEGRA_SOC, the channel CANNOT be converted to integer.
     add_event_detect(std::atoi(channel.data()), edge, callback, bounce_time);
 }
 
 void GPIO::add_event_detect(int channel, Edge edge, const Callback& callback, unsigned long bounce_time)
 {
+    // To do: replace it to add_event_detect(std::to_string(channel), ...);
+
     try {
         ChannelInfo ch_info = _channel_to_info(std::to_string(channel), true);
 
@@ -710,11 +713,14 @@ void GPIO::remove_event_detect(int channel) { remove_event_detect(std::to_string
 
 int GPIO::wait_for_edge(const std::string& channel, Edge edge, uint64_t bounce_time, uint64_t timeout)
 {
+    // To do: if the numbering mode is CVM or TEGRA_SOC, the channel CANNOT be converted to integer!
     return wait_for_edge(std::atoi(channel.data()), edge, bounce_time, timeout);
 }
 
 int GPIO::wait_for_edge(int channel, Edge edge, uint64_t bounce_time, uint64_t timeout)
 {
+    // To do: replace it to return wait_for_edge(std::to_string(channel), ...);
+
     try {
         ChannelInfo ch_info = _channel_to_info(std::to_string(channel), true);
 

--- a/src/JetsonGPIO.cpp
+++ b/src/JetsonGPIO.cpp
@@ -709,7 +709,7 @@ void GPIO::remove_event_detect(const std::string& channel)
 
 void GPIO::remove_event_detect(int channel) { remove_event_detect(std::to_string(channel)); }
 
-std::string GPIO::wait_for_edge(const std::string& channel, Edge edge, uint64_t bounce_time, uint64_t timeout)
+WaitResult GPIO::wait_for_edge(const std::string& channel, Edge edge, uint64_t bounce_time, uint64_t timeout)
 {
     try {
         ChannelInfo ch_info = _channel_to_info(channel, true);
@@ -730,7 +730,7 @@ std::string GPIO::wait_for_edge(const std::string& channel, Edge edge, uint64_t 
         switch (result) {
         case EventResultCode::None:
             // Timeout
-            return "";
+            return "None"s;
         case EventResultCode::EdgeDetected:
             // Event Detected
             return channel;
@@ -745,12 +745,9 @@ std::string GPIO::wait_for_edge(const std::string& channel, Edge edge, uint64_t 
     }
 }
 
-int GPIO::wait_for_edge(int channel, Edge edge, uint64_t bounce_time, uint64_t timeout)
+WaitResult GPIO::wait_for_edge(int channel, Edge edge, uint64_t bounce_time, uint64_t timeout)
 {
-    auto result = wait_for_edge(std::to_string(channel), edge, bounce_time, timeout);
-    if (result.empty())
-        return 0;
-    return std::stoi(result);
+    return wait_for_edge(std::to_string(channel), edge, bounce_time, timeout);
 }
 
 //=======================================
@@ -964,6 +961,18 @@ bool GPIO::operator!=(const GPIO::Callback& A, const GPIO::Callback& B)
 	return !(A == B);
 }
 //=======================================
+
+//=======================================
+// WaitResult
+GPIO::WaitResult::WaitResult(const std::string& channel) : _channel(channel){}
+GPIO::WaitResult::WaitResult(const GPIO::WaitResult&) = default;
+GPIO::WaitResult::WaitResult(GPIO::WaitResult&&) = default;
+GPIO::WaitResult& GPIO::WaitResult::operator=(const GPIO::WaitResult&) = default;
+GPIO::WaitResult& GPIO::WaitResult::operator=(GPIO::WaitResult&&) = default;
+
+bool GPIO::WaitResult::is_event_detected() const { return !is_None(channel()); }
+//=======================================
+
 
 
 //=======================================

--- a/src/gpio_event.cpp
+++ b/src/gpio_event.cpp
@@ -75,6 +75,7 @@ struct _gpioEventObject {
     enum ModifyEvent { NONE, ADD, INITIAL_ABSCOND, REMOVE, MODIFY } _epoll_change_flag;
     struct epoll_event _epoll_event;
 
+    // to do: change to std::string
     int channel_id;
     int gpio;
     int fd;

--- a/src/gpio_event.cpp
+++ b/src/gpio_event.cpp
@@ -75,8 +75,7 @@ struct _gpioEventObject {
     enum ModifyEvent { NONE, ADD, INITIAL_ABSCOND, REMOVE, MODIFY } _epoll_change_flag;
     struct epoll_event _epoll_event;
 
-    // to do: change to std::string
-    int channel_id;
+    std::string channel_id;
     int gpio;
     int fd;
     Edge edge;
@@ -355,7 +354,7 @@ void _epoll_end_thread()
 
 //-------------- Operations -------------------- //
 
-int _blocking_wait_for_edge(int gpio, const std::string& gpio_name, int channel_id, Edge edge, uint64_t bounce_time, uint64_t timeout)
+int _blocking_wait_for_edge(int gpio, const std::string& gpio_name, const std::string& channel_id, Edge edge, uint64_t bounce_time, uint64_t timeout)
 {
     timespec timeout_time{};
     if (timeout) {
@@ -604,7 +603,7 @@ bool _edge_event_exists(int gpio)
     return false;
 }
 
-int _add_edge_detect(int gpio, const std::string& gpio_name, int channel_id, Edge edge, uint64_t bounce_time)
+int _add_edge_detect(int gpio, const std::string& gpio_name, const std::string& channel_id, Edge edge, uint64_t bounce_time)
 {
     int result{};
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -29,6 +29,7 @@ DEALINGS IN THE SOFTWARE.
 #include <chrono>
 #include <iostream>
 #include <thread>
+#include <string>
 
 #include "JetsonGPIO.h"
 
@@ -61,19 +62,19 @@ inline void delay(int ms)
 
 void signalHandler(int s) { end_this_program = true; }
 
-void callback_fn(int button_pin)
+void callback_fn(const std::string& button_pin)
 {
     cout << "--Callback called from button_pin " << button_pin << endl;
     ++cb;
 }
 
-void callback_one(int button_pin)
+void callback_one(const std::string& button_pin)
 {
     cout << "--First Additional Callback" << endl;
     cb1 = true;
 }
 
-void callback_two(int button_pin)
+void callback_two(const std::string& button_pin)
 {
     cout << "--Second Additional Callback" << endl;
     cb2 = true;


### PR DESCRIPTION
This is a fix for the issue #39. 
**(Summary: The channel type in event module should be changed because it is NOT always convertible to int.  )**
Tested it with `samples/test_all_apis.cpp`. 

@ShimmyShaman 
Could you review the code please?  

Major changes:
- The signature of `wait_for_edge`, `add_event_detect ` functions changed 
- The signature of the callback changed

Want to discuss:
-  Any better idea for the return value of the `wait_for_edge` function?
   - it returns 0 on timeout if the channel is int. 
   - it returns an empty string on timeout if the channel is string. 
 