### PR TITLE
Add samples to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ SET(CMAKE_CXX_STANDARD 14)
 SET(LIBRARY_VERSION "1.1.0")
 SET(LIBRARY_SOVERSION "1")
 
+option(BUILD_EXAMPLES "Build examples" ON)
+
 SET (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
 
 find_package(Threads REQUIRED)
@@ -61,3 +63,8 @@ set(test_all_apis_SRCS
 
 add_executable(test_all_apis ${test_all_apis_SRCS})
 TARGET_LINK_LIBRARIES(test_all_apis JetsonGPIO Threads::Threads)
+
+# Build examples
+if (BUILD_EXAMPLES)
+add_subdirectory(samples)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ SET(CMAKE_CXX_STANDARD 14)
 SET(LIBRARY_VERSION "1.1.0")
 SET(LIBRARY_SOVERSION "1")
 
-option(BUILD_EXAMPLES "Build examples" ON)
+option(BUILD_EXAMPLES "Build examples" OFF)
 
 SET (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ mkdir build
 cd JetsonGPIO/build
 ```
 
-The following commands will build the library and install it to `/usr/local` directory by default.
-You can add `-DCMAKE_INSTALL_PREFIX=/usr` option to install it to `/usr` according to your preference.
+The following commands will build the library and install it to `/usr/local` directory by default.  
+- You can add `-DCMAKE_INSTALL_PREFIX=/usr` option to install it to `/usr` according to your preference.  
+- You can add `-DBUILD_EXAMPLES=ON` option to build example codes in `samples`.
+
 ```
-cmake ../
+cmake ..
 sudo make install
 ```
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(_example_targets
+    "button_event"
+    "button_interrupt"
+    "simple_out"
+    "simple_pwm"
+    )
+
+foreach (example ${_example_targets})
+  add_executable(${example} ${example}.cpp)
+  target_link_libraries(${example} PRIVATE JetsonGPIO)
+endforeach ()
+
+add_custom_target(examples)
+add_dependencies(examples ${_example_targets})


### PR DESCRIPTION
This will add the examples to the CMake build.

```sh
mkdir build && cd build
cmake ..
# This will build everything
make
# This will build only the library
make JetsonGPIO
# This will build the examples
make examples
```

- Examples will be configured/built unless `-DBUILD_EXAMPLES=OFF` is passed to `cmake`.
  We can choose to enforce the opposite behavior by putting this instead:
  ```cmake
  option(BUILD_EXAMPLES "Build examples" OFF)
  ```
  So examples will be configured /built only if we pass `-DBUILD_EXAMPLES=ON` to `cmake`.
  
- I didn't add `samples/test_all_apis.cpp` to the examples since it's already there as a test.
- At the moment, the generated binaries will *not* be installed.