### PR TITLE
Add post install script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(GNUInstallDirs)
 SET(CMAKE_CXX_STANDARD 14)
 
 option(BUILD_EXAMPLES "Build examples" OFF)
+option(POST_INSTALL "Create gpio group and reload udev rules" ON)
 
 SET (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
 
@@ -88,6 +89,11 @@ install(FILES
 
 # Install Udev rules
 install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-gpio.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+
+# Run post installation script
+if (POST_INSTALL)
+install (CODE "execute_process(COMMAND ./post_install.sh WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")
+endif()
 
 # Build Test
 set(JetsonGPIO_test_SRCS

--- a/post_install.sh
+++ b/post_install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+echo "Creating group gpio..."
+groupadd -f -r gpio
+LOGNAME=$(logname)
+echo "Adding $LOGNAME to gpio..."
+usermod -a -G gpio $LOGNAME
+echo "Reloading udev rules..."
+udevadm control --reload-rules
+udevadm trigger
+echo "Done"


### PR DESCRIPTION
I wrote a script that does the steps in the "Setting User Permissions" section of the README, and I added it to the installation with CMake. It runs if `POST_INSTALL=ON` (default `ON` at the moment).