### PR TITLE
Improve runtime exception handling on the unsupported devices (Fix for #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,13 +220,13 @@ GPIO::cleanup(chan1); // cleanup only chan1
 To get information about the Jetson module, use/read:
 
 ```cpp
-std::string info = GPIO::JETSON_INFO;
+std::string info = GPIO::JETSON_INFO();
 ```
 
 To get the model name of your Jetson device, use/read:
 
 ```cpp
-std::string model = GPIO::model;
+std::string model = GPIO::model();
 ```
 
 To get information about the library version, use/read:

--- a/include/JetsonGPIO.h
+++ b/include/JetsonGPIO.h
@@ -63,8 +63,8 @@ namespace GPIO
 {
     constexpr auto VERSION = JETSONGPIO_VERSION;
 
-    extern const std::string JETSON_INFO;
-    extern const std::string model;
+    std::string JETSON_INFO();
+    std::string model();
 
     // Pin Numbering Modes
     enum class NumberingModes

--- a/samples/simple_pwm.cpp
+++ b/samples/simple_pwm.cpp
@@ -42,13 +42,13 @@ const map<string, int> output_pins{
 
 int get_output_pin()
 {
-    if (output_pins.find(GPIO::model) == output_pins.end())
+    if (output_pins.find(GPIO::model()) == output_pins.end())
     {
         cerr << "PWM not supported on this board\n";
         terminate();
     }
 
-    return output_pins.at(GPIO::model);
+    return output_pins.at(GPIO::model());
 }
 
 inline void delay(double s) { this_thread::sleep_for(std::chrono::duration<double>(s)); }

--- a/tests/test_all_apis.cpp
+++ b/tests/test_all_apis.cpp
@@ -178,7 +178,7 @@ private:
         throw std::runtime_error("invalid model");
     }
 
-    TestPinData pin_data = get_test_pin_data(GPIO::model);
+    TestPinData pin_data = get_test_pin_data(GPIO::model());
     std::vector<int> all_board_pins = {7,  11, 12, 13, 15, 16, 18, 19, 21, 22, 23,
                                        24, 26, 29, 31, 32, 33, 35, 36, 37, 38, 40};
     int bcm_pin = 4;
@@ -644,8 +644,8 @@ private:
 
         std::cout << line << std::endl;
         std::cout << "[Library Version] " << GPIO::VERSION << std::endl;
-        std::cout << "[Model] " << GPIO::model << std::endl;
-        std::cout << GPIO::JETSON_INFO;
+        std::cout << "[Model] " << GPIO::model() << std::endl;
+        std::cout << GPIO::JETSON_INFO();
         std::cout << line << std::endl;
 
         std::cout << "[NOTE]" << std::endl;

--- a/tests/test_event_module.cpp
+++ b/tests/test_event_module.cpp
@@ -345,9 +345,9 @@ void testEventsConcurrency()
 
 int main()
 {
-    cout << "model: " << GPIO::model << endl;
+    cout << "model: " << GPIO::model() << endl;
     cout << "lib version: " << GPIO::VERSION << endl;
-    cout << GPIO::JETSON_INFO << endl;
+    cout << GPIO::JETSON_INFO() << endl;
 
     // When CTRL+C pressed, signalHandler will be called
     signal(SIGINT, signalHandler);


### PR DESCRIPTION
Improve runtime exception handling on the unsupported devices (ex> desktop PC), 
- related to the issue #62
- remove the global variables to make the GlobalVariablesForGPIO be initialized lazily.
- On the unsupported devices, the library will throw an exception on the first API call. If there is no API call, it will not throw an exception.  
- changed the public API for `GPIO::model` and `GPIO::JETSON_INFO` (variables to functions)
