### PR TITLE
fix for _edge_event_exists function

### DIFF
--- a/src/JetsonGPIO.cpp
+++ b/src/JetsonGPIO.cpp
@@ -643,7 +643,7 @@ void GPIO::add_event_callback(const std::string& channel, const Callback& callba
         }
 
         // edge event must already exist
-        if (_edge_event_exists(ch_info.gpio))
+        if (!_edge_event_exists(ch_info.gpio))
             throw runtime_error("The edge event must have been set via add_event_detect()");
 
         // Execute

--- a/src/gpio_event.cpp
+++ b/src/gpio_event.cpp
@@ -678,7 +678,7 @@ namespace GPIO
         std::lock_guard<std::recursive_mutex> mutex_lock(_epmutex);
 
         auto find_result = _gpio_events.find(gpio);
-        if (find_result == _gpio_events.end())
+        if (find_result != _gpio_events.end())
         {
             return find_result->second->_epoll_change_flag != _gpioEventObject::ModifyEvent::REMOVE;
         }

--- a/tests/test_all_apis.cpp
+++ b/tests/test_all_apis.cpp
@@ -638,6 +638,24 @@ private:
         }
     }
 
+    void test_add_callback_before_add_event_detect()
+    {
+        GPIO::setmode(GPIO::BOARD);
+        GPIO::setup(pin_data.in_a, GPIO::IN);
+
+        bool event_callback_occurred = false;
+        TestCallback callback(&event_callback_occurred, std::to_string(pin_data.in_a));
+
+        auto invalid_operation = [this, &callback]()
+        {
+            // must thorw an exception
+            GPIO::add_event_callback(pin_data.in_a, callback);
+        };
+
+        expect_exception(invalid_operation);
+        GPIO::cleanup();
+    }
+
     void print_info()
     {
         const auto line = "==========================";
@@ -692,6 +710,7 @@ private:
         ADD_TEST(test_event_detected_rising);
         ADD_TEST(test_event_detected_falling);
         ADD_TEST(test_event_detected_both);
+        ADD_TEST(test_add_callback_before_add_event_detect);
 
         // pwm
         if (!pin_data.all_pwms.empty())
@@ -712,6 +731,22 @@ private:
     {
         if (b == false)
             throw std::runtime_error("assert fail");
+    }
+
+    void expect_exception(std::function<void(void)> work) const
+    {
+        bool exception_occured = false;
+
+        try
+        {
+            work();
+        }
+        catch(...)
+        {
+            exception_occured = true;
+        }
+
+        assert(exception_occured);
     }
 
     void _test_events(int init, GPIO::Edge edge, const std::vector<std::pair<int, bool>>& tests, bool specify_callback,


### PR DESCRIPTION
I found a minor error from `_edge_event_exists` function in the event module. 

- fix  `_edge_event_exists` function logic

 `find_result != _gpio_events.end()` here. `find_result->second` will throw an exception when the if statement is true.
https://github.com/pjueon/JetsonGPIO/blob/4fc83abf2e402d56440852bdb2a58b2b5596b409/src/gpio_event.cpp#L680-L685

Should be `if (!_edge_event_exists(ch_info.gpio))` here, judging by the function name and the comment.
https://github.com/pjueon/JetsonGPIO/blob/4fc83abf2e402d56440852bdb2a58b2b5596b409/src/JetsonGPIO.cpp#L645-L647

In most cases the original code would work except for the case that `find_result != _gpio_events.end() && find_result->second->_epoll_change_flag == _gpioEventObject::ModifyEvent::REMOVE`.

- add a testcase to check if an exception is thrown when `GPIO::add_event_callback` is called before `GPIO::add_event_detect` 

@ShimmyShaman 