### PR TITLE
Cleanup headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ INSTALL(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/include/JetsonGPIO.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
+file(GLOB JetsonGPIO_Public_Headers ${CMAKE_CURRENT_SOURCE_DIR}/include/JetsonGPIO/*.h)
+install( FILES ${JetsonGPIO_Public_Headers} DESTINATION include/JetsonGPIO)
+
 # Install the auto-generated configuration header
 install(FILES ${PROJECT_BINARY_DIR}/JetsonGPIOConfig.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/include/JetsonGPIO.h
+++ b/include/JetsonGPIO.h
@@ -27,151 +27,25 @@ DEALINGS IN THE SOFTWARE.
 #ifndef JETSON_GPIO_H
 #define JETSON_GPIO_H
 
-#include <functional>
-#include <memory> // for pImpl
 #include <string>
-#include <type_traits>
 
+#include "JetsonGPIO/Callback.h"
+#include "JetsonGPIO/LazyString.h"
+#include "JetsonGPIO/PublicEnums.h"
+#include "JetsonGPIO/TypeTraits.h"
+#include "JetsonGPIO/WaitResult.h"
+#include "JetsonGPIO/PWM.h"
 #include "JetsonGPIOConfig.h"
-
-#if (__cplusplus >= 201402L) && !defined(CPP14_SUPPORTED)
-#define CPP14_SUPPORTED
-#endif
-
-#if (__cplusplus >= 201703L) && !defined(CPP17_SUPPORTED)
-#define CPP17_SUPPORTED
-#endif
-
-#ifndef CPP14_SUPPORTED
-// define C++14 features
-namespace std
-{
-    template <class T> using decay_t = typename decay<T>::type;
-    template <bool B, class T = void> using enable_if_t = typename enable_if<B, T>::type;
-} // namespace std
-#endif
-
-#ifndef CPP17_SUPPORTED
-// define C++17 features
-namespace std
-{
-    template <class...> using void_t = void;
-}
-#endif
-
-#define _ARG_COUNT(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, N, ...) N
-#define _EXPAND(x) x
-#define ARG_COUNT(...)                                                                                                 \
-    _EXPAND(_ARG_COUNT(__VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1))
 
 namespace GPIO
 {
     constexpr auto VERSION = JETSONGPIO_VERSION;
 
-    class LazyString // lazily evaluated string object
-    {
-    public:
-        LazyString(const std::function<std::string(void)>& func);
-        LazyString(const std::string& str);
-        LazyString(const char* str);
-
-        LazyString(const LazyString&) = default;
-        LazyString(LazyString&&) = default;
-
-        LazyString& operator=(const LazyString&) = default;
-        LazyString& operator=(LazyString&&) = default;
-
-        operator const char*() const;
-        operator std::string() const;
-        const std::string& operator()() const;
-
-    private:
-        mutable std::string buffer;
-        mutable bool is_cached;
-        std::function<std::string(void)> func;
-        void Evaluate() const;
-    };
-
-    namespace details
-    {
-        template <class T>
-        constexpr bool is_string =
-            std::is_constructible<LazyString, T>::value && !std::is_same<std::decay_t<T>, nullptr_t>::value;
-
-        template <class T1, class T2>
-        constexpr bool is_lazy_string_comparision = is_string<T1>&& is_string<T2> &&
-                                                    (std::is_same<std::decay_t<T1>, LazyString>::value ||
-                                                     std::is_same<std::decay_t<T2>, LazyString>::value);
-    } // namespace details
-
-    template <class T1, class T2, class = std::enable_if_t<details::is_lazy_string_comparision<T1, T2>>>
-    bool operator==(T1&& a, T2&& b)
-    {
-        LazyString _a(std::forward<T1>(a));
-        LazyString _b(std::forward<T2>(b));
-        return _a() == _b();
-    }
-
-    template <class T1, class T2, class = std::enable_if_t<details::is_lazy_string_comparision<T1, T2>>>
-    bool operator!=(T1&& a, T2&& b)
-    {
-        return !(a == b);
-    }
-
     extern LazyString JETSON_INFO;
     extern LazyString model;
 
-    namespace details
-    {
-        template <class E> struct enum_size
-        {
-        };
-    } // namespace details
-
-#define PUBLIC_ENUM_CLASS(NAME, ...)                                                                                   \
-    enum class NAME                                                                                                    \
-    {                                                                                                                  \
-        __VA_ARGS__                                                                                                    \
-    };                                                                                                                 \
-                                                                                                                       \
-    template <> struct details::enum_size<NAME>                                                                        \
-    {                                                                                                                  \
-        static constexpr size_t value = ARG_COUNT(__VA_ARGS__);                                                        \
-    }
-
-    // Pin Numbering Modes
-    PUBLIC_ENUM_CLASS(NumberingModes, BOARD, BCM, TEGRA_SOC, CVM, None);
-
-    // alias for GPIO::NumberingModes
-    constexpr NumberingModes BOARD = NumberingModes::BOARD;
-    constexpr NumberingModes BCM = NumberingModes::BCM;
-    constexpr NumberingModes TEGRA_SOC = NumberingModes::TEGRA_SOC;
-    constexpr NumberingModes CVM = NumberingModes::CVM;
-
-    // Pull up/down options are removed because they are unused in NVIDIA's original python libarary.
-    // check: https://github.com/NVIDIA/jetson-gpio/issues/5
-
     constexpr int HIGH = 1;
     constexpr int LOW = 0;
-
-    // GPIO directions.
-    // UNKNOWN constant is for gpios that are not yet setup
-    // If the user uses UNKNOWN or HARD_PWM as a parameter to GPIO::setmode function,
-    // An exception will occur
-    PUBLIC_ENUM_CLASS(Directions, UNKNOWN, OUT, IN, HARD_PWM);
-
-    // alias for GPIO::Directions
-    constexpr Directions IN = Directions::IN;
-    constexpr Directions OUT = Directions::OUT;
-
-    // GPIO Event Types
-    PUBLIC_ENUM_CLASS(Edge, UNKNOWN, NONE, RISING, FALLING, BOTH);
-
-    // alias for GPIO::Edge
-    constexpr Edge NO_EDGE = Edge::NONE;
-    constexpr Edge RISING = Edge::RISING;
-    constexpr Edge FALLING = Edge::FALLING;
-    constexpr Edge BOTH = Edge::BOTH;
 
     // Function used to enable/disable warnings during setup and cleanup.
     void setwarnings(bool state);
@@ -207,172 +81,6 @@ namespace GPIO
     /* Function used to check the currently set function of the channel specified. */
     Directions gpio_function(const std::string& channel);
     Directions gpio_function(int channel);
-
-    //----------------------------------
-
-    // Callback definition
-    class Callback;
-    bool operator==(const Callback& A, const Callback& B);
-    bool operator!=(const Callback& A, const Callback& B);
-
-    namespace details
-    {
-        class NoArgCallback;
-
-        // type traits
-        enum class CallbackType
-        {
-            Normal,
-            NoArg
-        };
-
-        template <CallbackType e> struct CallbackConstructorOverload
-        {
-        };
-
-        template <class T, class = void> struct is_equality_comparable : std::false_type
-        {
-        };
-
-        template <class T>
-        struct is_equality_comparable<T, std::void_t<decltype(std::declval<T>() == std::declval<T>())>>
-        : std::is_convertible<decltype(std::declval<T>() == std::declval<T>()), bool>
-        {
-        };
-
-        template <class T> constexpr bool is_equality_comparable_v = is_equality_comparable<T>::value;
-
-        template <class T>
-        constexpr bool is_no_argument_callback =
-            !std::is_same<std::decay_t<T>, NoArgCallback>::value && std::is_constructible<NoArgCallback, T&&>::value;
-
-        template <class T>
-        constexpr bool is_string_argument_callback =
-            std::is_constructible<std::function<void(const std::string&)>, T&&>::value;
-
-        template <class T> constexpr CallbackType CallbackTypeSelector()
-        {
-            static_assert(std::is_copy_constructible<std::decay_t<T>>::value, "Callback must be copy-constructible");
-
-            static_assert(is_no_argument_callback<T> || is_string_argument_callback<T>, "Callback must be callable");
-
-            static_assert(is_equality_comparable_v<const T&>,
-                          "Callback function MUST be equality comparable. ex> f0 == f1");
-
-            return is_string_argument_callback<T> ? CallbackType::Normal : CallbackType::NoArg;
-        }
-
-        template <class arg_t> struct CallbackCompare
-        {
-            using func_t = std::function<arg_t>;
-
-            template <class T> static bool Compare(const func_t& A, const func_t& B)
-            {
-                if (A == nullptr && B == nullptr)
-                    return true;
-
-                const T* targetA = A.template target<T>();
-                const T* targetB = B.template target<T>();
-
-                return targetA != nullptr && targetB != nullptr && *targetA == *targetB;
-            }
-        };
-
-        class NoArgCallback
-        {
-        private:
-            using func_t = std::function<void()>;
-            using comparer_impl = details::CallbackCompare<void()>;
-
-        public:
-            NoArgCallback(const NoArgCallback&) = default;
-            NoArgCallback(NoArgCallback&&) = default;
-
-            template <class T, class = std::enable_if_t<!std::is_same<std::decay_t<T>, nullptr_t>::value &&
-                                                        std::is_constructible<func_t, T&&>::value>>
-            NoArgCallback(T&& function)
-            : function(std::forward<T>(function)), comparer(comparer_impl::Compare<std::decay_t<T>>)
-            {
-            }
-
-            NoArgCallback& operator=(const NoArgCallback&) = default;
-            NoArgCallback& operator=(NoArgCallback&&) = default;
-
-            bool operator==(const NoArgCallback& other) const { return comparer(function, other.function); }
-            bool operator!=(const NoArgCallback& other) const { return !(*this == other); }
-
-            void operator()(const std::string&) const { function(); }
-
-        private:
-            func_t function;
-            std::function<bool(const func_t&, const func_t&)> comparer;
-        };
-
-    } // namespace details
-
-    class Callback
-    {
-    private:
-        using func_t = std::function<void(const std::string&)>;
-        using comparer_impl = details::CallbackCompare<void(const std::string&)>;
-
-        template <class T>
-        Callback(T&& function, details::CallbackConstructorOverload<details::CallbackType::Normal>)
-        : function(std::forward<T>(function)), comparer(comparer_impl::Compare<std::decay_t<T>>)
-        {
-            static_assert(std::is_constructible<func_t, T&&>::value,
-                          "Callback return type: void, argument type: const std::string&");
-        }
-
-        template <class T>
-        Callback(T&& noArgFunction, details::CallbackConstructorOverload<details::CallbackType::NoArg>)
-        : function(details::NoArgCallback(std::forward<T>(noArgFunction))),
-          comparer(comparer_impl::Compare<details::NoArgCallback>)
-        {
-        }
-
-    public:
-        Callback(const Callback&) = default;
-        Callback(Callback&&) = default;
-
-        template <class T>
-        Callback(T&& function)
-        : Callback(std::forward<T>(function),
-                   details::CallbackConstructorOverload<details::CallbackTypeSelector<T>()>{})
-        {
-        }
-
-        Callback& operator=(const Callback&) = default;
-        Callback& operator=(Callback&&) = default;
-
-        void operator()(const std::string& input) const;
-
-        friend bool operator==(const Callback& A, const Callback& B);
-        friend bool operator!=(const Callback& A, const Callback& B);
-
-    private:
-        func_t function;
-        std::function<bool(const func_t&, const func_t&)> comparer;
-    };
-
-    class WaitResult
-    {
-    public:
-        WaitResult(const std::string& channel);
-        WaitResult(const WaitResult&) = default;
-        WaitResult(WaitResult&&) = default;
-        WaitResult& operator=(const WaitResult&) = default;
-        WaitResult& operator=(WaitResult&&) = default;
-
-        inline const std::string& channel() const { return _channel; }
-        bool is_event_detected() const;
-        inline operator bool() const { return is_event_detected(); }
-
-    private:
-        std::string _channel;
-    };
-
-    //----------------------------------
 
     /* Function used to check if an event occurred on the specified channel.
        Param channel must be an integer or a string.
@@ -413,28 +121,6 @@ namespace GPIO
                              unsigned long timeout = 0);
     WaitResult wait_for_edge(int channel, Edge edge, unsigned long bounce_time = 0, unsigned long timeout = 0);
 
-    //----------------------------------
-
-    class PWM
-    {
-    public:
-        PWM(const std::string& channel, int frequency_hz);
-        PWM(int channel, int frequency_hz);
-        PWM(PWM&& other);
-        PWM& operator=(PWM&& other);
-        PWM(const PWM&) = delete;            // Can't create duplicate PWM objects
-        PWM& operator=(const PWM&) = delete; // Can't create duplicate PWM objects
-        ~PWM();
-        void start(double duty_cycle_percent);
-        void stop();
-        void ChangeFrequency(int frequency_hz);
-        void ChangeDutyCycle(double duty_cycle_percent);
-
-    private:
-        struct Impl;
-        std::unique_ptr<Impl> pImpl;
-    };
 } // namespace GPIO
 
-#undef PUBLIC_ENUM_CLASS
 #endif // JETSON_GPIO_H

--- a/include/JetsonGPIO/Callback.h
+++ b/include/JetsonGPIO/Callback.h
@@ -1,0 +1,171 @@
+/*
+Copyright (c) 2012-2017 Ben Croston ben@croston.org.
+Copyright (c) 2019, NVIDIA CORPORATION.
+Copyright (c) 2019 Jueon Park(pjueon) bluegbg@gmail.com.
+Copyright (c) 2021 Adam Rasburn blackforestcheesecake@protonmail.ch
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+#ifndef CALLBACK_H
+#define CALLBACK_H
+
+#include "JetsonGPIO/TypeTraits.h"
+#include <functional>
+#include <string>
+
+namespace GPIO
+{
+    // Callback definition
+    class Callback;
+    bool operator==(const Callback& A, const Callback& B);
+    bool operator!=(const Callback& A, const Callback& B);
+
+    namespace details
+    {
+        class NoArgCallback;
+
+        // type traits
+        enum class CallbackType
+        {
+            Normal,
+            NoArg
+        };
+
+        template <CallbackType e> struct CallbackConstructorOverload
+        {
+        };
+
+        template <class T>
+        constexpr bool is_no_argument_callback =
+            !std::is_same<std::decay_t<T>, NoArgCallback>::value && std::is_constructible<NoArgCallback, T&&>::value;
+
+        template <class T>
+        constexpr bool is_string_argument_callback =
+            std::is_constructible<std::function<void(const std::string&)>, T&&>::value;
+
+        template <class T> constexpr CallbackType CallbackTypeSelector()
+        {
+            static_assert(std::is_copy_constructible<std::decay_t<T>>::value, "Callback must be copy-constructible");
+
+            static_assert(is_no_argument_callback<T> || is_string_argument_callback<T>, "Callback must be callable");
+
+            static_assert(is_equality_comparable_v<const T&>,
+                          "Callback function MUST be equality comparable. ex> f0 == f1");
+
+            return is_string_argument_callback<T> ? CallbackType::Normal : CallbackType::NoArg;
+        }
+
+        template <class arg_t> struct CallbackCompare
+        {
+            using func_t = std::function<arg_t>;
+
+            template <class T> static bool Compare(const func_t& A, const func_t& B)
+            {
+                if (A == nullptr && B == nullptr)
+                    return true;
+
+                const T* targetA = A.template target<T>();
+                const T* targetB = B.template target<T>();
+
+                return targetA != nullptr && targetB != nullptr && *targetA == *targetB;
+            }
+        };
+
+        class NoArgCallback
+        {
+        private:
+            using func_t = std::function<void()>;
+            using comparer_impl = details::CallbackCompare<void()>;
+
+        public:
+            NoArgCallback(const NoArgCallback&) = default;
+            NoArgCallback(NoArgCallback&&) = default;
+
+            template <class T, class = std::enable_if_t<!std::is_same<std::decay_t<T>, nullptr_t>::value &&
+                                                        std::is_constructible<func_t, T&&>::value>>
+            NoArgCallback(T&& function)
+            : function(std::forward<T>(function)), comparer(comparer_impl::Compare<std::decay_t<T>>)
+            {
+            }
+
+            NoArgCallback& operator=(const NoArgCallback&) = default;
+            NoArgCallback& operator=(NoArgCallback&&) = default;
+
+            bool operator==(const NoArgCallback& other) const { return comparer(function, other.function); }
+            bool operator!=(const NoArgCallback& other) const { return !(*this == other); }
+
+            void operator()(const std::string&) const { function(); }
+
+        private:
+            func_t function;
+            std::function<bool(const func_t&, const func_t&)> comparer;
+        };
+
+    } // namespace details
+
+    class Callback
+    {
+    private:
+        using func_t = std::function<void(const std::string&)>;
+        using comparer_impl = details::CallbackCompare<void(const std::string&)>;
+
+        template <class T>
+        Callback(T&& function, details::CallbackConstructorOverload<details::CallbackType::Normal>)
+        : function(std::forward<T>(function)), comparer(comparer_impl::Compare<std::decay_t<T>>)
+        {
+            static_assert(std::is_constructible<func_t, T&&>::value,
+                          "Callback return type: void, argument type: const std::string&");
+        }
+
+        template <class T>
+        Callback(T&& noArgFunction, details::CallbackConstructorOverload<details::CallbackType::NoArg>)
+        : function(details::NoArgCallback(std::forward<T>(noArgFunction))),
+          comparer(comparer_impl::Compare<details::NoArgCallback>)
+        {
+        }
+
+    public:
+        Callback(const Callback&) = default;
+        Callback(Callback&&) = default;
+
+        template <class T>
+        Callback(T&& function)
+        : Callback(std::forward<T>(function),
+                   details::CallbackConstructorOverload<details::CallbackTypeSelector<T>()>{})
+        {
+        }
+
+        Callback& operator=(const Callback&) = default;
+        Callback& operator=(Callback&&) = default;
+
+        void operator()(const std::string& input) const;
+
+        friend bool operator==(const Callback& A, const Callback& B);
+        friend bool operator!=(const Callback& A, const Callback& B);
+
+    private:
+        func_t function;
+        std::function<bool(const func_t&, const func_t&)> comparer;
+    };
+
+} // namespace GPIO
+
+#endif

--- a/include/JetsonGPIO/Callback.h
+++ b/include/JetsonGPIO/Callback.h
@@ -67,7 +67,7 @@ namespace GPIO
 
             static_assert(is_no_argument_callback<T> || is_string_argument_callback<T>, "Callback must be callable");
 
-            static_assert(is_equality_comparable_v<const T&>,
+            static_assert(details::is_equality_comparable_v<const T&>,
                           "Callback function MUST be equality comparable. ex> f0 == f1");
 
             return is_string_argument_callback<T> ? CallbackType::Normal : CallbackType::NoArg;

--- a/include/JetsonGPIO/LazyString.h
+++ b/include/JetsonGPIO/LazyString.h
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2012-2017 Ben Croston ben@croston.org.
+Copyright (c) 2019, NVIDIA CORPORATION.
+Copyright (c) 2019 Jueon Park(pjueon) bluegbg@gmail.com.
+Copyright (c) 2021 Adam Rasburn blackforestcheesecake@protonmail.ch
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+#ifndef LAZY_STRING_H
+#define LAZY_STRING_H
+
+#include <functional>
+#include <string>
+#include <type_traits>
+
+namespace GPIO
+{
+    class LazyString // lazily evaluated string object
+    {
+    public:
+        LazyString(const std::function<std::string(void)>& func);
+        LazyString(const std::string& str);
+        LazyString(const char* str);
+
+        LazyString(const LazyString&) = default;
+        LazyString(LazyString&&) = default;
+
+        LazyString& operator=(const LazyString&) = default;
+        LazyString& operator=(LazyString&&) = default;
+
+        operator const char*() const;
+        operator std::string() const;
+        const std::string& operator()() const;
+
+    private:
+        mutable std::string buffer;
+        mutable bool is_cached;
+        std::function<std::string(void)> func;
+        void Evaluate() const;
+    };
+
+    namespace details
+    {
+        template <class T>
+        constexpr bool is_string =
+            std::is_constructible<LazyString, T>::value && !std::is_same<std::decay_t<T>, nullptr_t>::value;
+
+        template <class T1, class T2>
+        constexpr bool is_lazy_string_comparision = is_string<T1>&& is_string<T2> &&
+                                                    (std::is_same<std::decay_t<T1>, LazyString>::value ||
+                                                     std::is_same<std::decay_t<T2>, LazyString>::value);
+    } // namespace details
+
+    template <class T1, class T2, class = std::enable_if_t<details::is_lazy_string_comparision<T1, T2>>>
+    bool operator==(T1&& a, T2&& b)
+    {
+        LazyString _a(std::forward<T1>(a));
+        LazyString _b(std::forward<T2>(b));
+        return _a() == _b();
+    }
+
+    template <class T1, class T2, class = std::enable_if_t<details::is_lazy_string_comparision<T1, T2>>>
+    bool operator!=(T1&& a, T2&& b)
+    {
+        return !(a == b);
+    }
+} // namespace GPIO
+
+#endif

--- a/include/JetsonGPIO/LazyString.h
+++ b/include/JetsonGPIO/LazyString.h
@@ -69,19 +69,20 @@ namespace GPIO
                                                      std::is_same<std::decay_t<T2>, LazyString>::value);
     } // namespace details
 
-    template <class T1, class T2, class = std::enable_if_t<details::is_lazy_string_comparision<T1, T2>>>
-    bool operator==(T1&& a, T2&& b)
-    {
-        LazyString _a(std::forward<T1>(a));
-        LazyString _b(std::forward<T2>(b));
-        return _a() == _b();
-    }
-
-    template <class T1, class T2, class = std::enable_if_t<details::is_lazy_string_comparision<T1, T2>>>
-    bool operator!=(T1&& a, T2&& b)
-    {
-        return !(a == b);
-    }
 } // namespace GPIO
+
+template <class T1, class T2, class = std::enable_if_t<GPIO::details::is_lazy_string_comparision<T1, T2>>>
+bool operator==(T1&& a, T2&& b)
+{
+    GPIO::LazyString _a(std::forward<T1>(a));
+    GPIO::LazyString _b(std::forward<T2>(b));
+    return _a() == _b();
+}
+
+template <class T1, class T2, class = std::enable_if_t<GPIO::details::is_lazy_string_comparision<T1, T2>>>
+bool operator!=(T1&& a, T2&& b)
+{
+    return !(a == b);
+}
 
 #endif

--- a/include/JetsonGPIO/PWM.h
+++ b/include/JetsonGPIO/PWM.h
@@ -23,34 +23,35 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
 
-#include "JetsonGPIO/LazyString.h"
+#pragma once
+#ifndef PWM_H
+#define PWM_H
+
+#include <memory>
+#include <string>
 
 namespace GPIO
 {
-    LazyString::LazyString(const std::function<std::string(void)>& func) : buffer(), is_cached(false), func(func) {}
-
-    LazyString::LazyString(const std::string& str) : buffer(str), is_cached(true), func() {}
-
-    LazyString::LazyString(const char* str) : buffer(str == nullptr ? "" : str), is_cached(true), func() {}
-
-    LazyString::operator const char*() const { return this->operator()().c_str(); }
-
-    LazyString::operator std::string() const { return this->operator()(); }
-
-    const std::string& LazyString::operator()() const
+    class PWM
     {
-        Evaluate();
-        return buffer;
-    }
+    public:
+        PWM(const std::string& channel, int frequency_hz);
+        PWM(int channel, int frequency_hz);
+        PWM(PWM&& other);
+        PWM& operator=(PWM&& other);
+        PWM(const PWM&) = delete;            // Can't create duplicate PWM objects
+        PWM& operator=(const PWM&) = delete; // Can't create duplicate PWM objects
+        ~PWM();
+        void start(double duty_cycle_percent);
+        void stop();
+        void ChangeFrequency(int frequency_hz);
+        void ChangeDutyCycle(double duty_cycle_percent);
 
-    void LazyString::Evaluate() const
-    {
-        if (is_cached)
-            return;
+    private:
+        struct Impl;
+        std::unique_ptr<Impl> pImpl;
+    };
 
-        if (func != nullptr)
-            buffer = func();
-
-        is_cached = true;
-    }
 } // namespace GPIO
+
+#endif

--- a/include/JetsonGPIO/PublicEnums.h
+++ b/include/JetsonGPIO/PublicEnums.h
@@ -87,4 +87,5 @@ namespace GPIO
 
 } // namespace GPIO
 
+#undef PUBLIC_ENUM_CLASS
 #endif

--- a/include/JetsonGPIO/PublicEnums.h
+++ b/include/JetsonGPIO/PublicEnums.h
@@ -1,0 +1,90 @@
+/*
+Copyright (c) 2012-2017 Ben Croston ben@croston.org.
+Copyright (c) 2019, NVIDIA CORPORATION.
+Copyright (c) 2019 Jueon Park(pjueon) bluegbg@gmail.com.
+Copyright (c) 2021 Adam Rasburn blackforestcheesecake@protonmail.ch
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+#ifndef PUBLIC_ENUMS_H
+#define PUBLIC_ENUMS_H
+
+#include <cstdio> // for size_t
+
+#define _ARG_COUNT(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, N, ...) N
+#define _EXPAND(x) x
+#define ARG_COUNT(...)                                                                                                 \
+    _EXPAND(_ARG_COUNT(__VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1))
+
+#define PUBLIC_ENUM_CLASS(NAME, ...)                                                                                   \
+    enum class NAME                                                                                                    \
+    {                                                                                                                  \
+        __VA_ARGS__                                                                                                    \
+    };                                                                                                                 \
+                                                                                                                       \
+    template <> struct details::enum_size<NAME>                                                                        \
+    {                                                                                                                  \
+        static constexpr size_t value = ARG_COUNT(__VA_ARGS__);                                                        \
+    }
+
+namespace GPIO
+{
+    namespace details
+    {
+        template <class E> struct enum_size
+        {
+        };
+    } // namespace details
+
+    // Pin Numbering Modes
+    PUBLIC_ENUM_CLASS(NumberingModes, BOARD, BCM, TEGRA_SOC, CVM, None);
+
+    // GPIO directions.
+    // UNKNOWN constant is for gpios that are not yet setup
+    // If the user uses UNKNOWN or HARD_PWM as a parameter to GPIO::setmode function,
+    // An exception will occur
+    PUBLIC_ENUM_CLASS(Directions, UNKNOWN, OUT, IN, HARD_PWM);
+
+    // GPIO Event Types
+    PUBLIC_ENUM_CLASS(Edge, UNKNOWN, NONE, RISING, FALLING, BOTH);
+
+    // alias for GPIO::NumberingModes
+    constexpr NumberingModes BOARD = NumberingModes::BOARD;
+    constexpr NumberingModes BCM = NumberingModes::BCM;
+    constexpr NumberingModes TEGRA_SOC = NumberingModes::TEGRA_SOC;
+    constexpr NumberingModes CVM = NumberingModes::CVM;
+
+    // Pull up/down options are removed because they are unused in NVIDIA's original python libarary.
+    // check: https://github.com/NVIDIA/jetson-gpio/issues/5
+
+    // alias for GPIO::Directions
+    constexpr Directions IN = Directions::IN;
+    constexpr Directions OUT = Directions::OUT;
+
+    // alias for GPIO::Edge
+    constexpr Edge NO_EDGE = Edge::NONE;
+    constexpr Edge RISING = Edge::RISING;
+    constexpr Edge FALLING = Edge::FALLING;
+    constexpr Edge BOTH = Edge::BOTH;
+
+} // namespace GPIO
+
+#endif

--- a/include/JetsonGPIO/TypeTraits.h
+++ b/include/JetsonGPIO/TypeTraits.h
@@ -48,17 +48,20 @@ namespace std
 
 namespace GPIO
 {
-    template <class T, class = void> struct is_equality_comparable : std::false_type
+    namespace details
     {
-    };
+        template <class T, class = void> struct is_equality_comparable : std::false_type
+        {
+        };
 
-    template <class T>
-    struct is_equality_comparable<T, std::void_t<decltype(std::declval<T>() == std::declval<T>())>>
-    : std::is_convertible<decltype(std::declval<T>() == std::declval<T>()), bool>
-    {
-    };
+        template <class T>
+        struct is_equality_comparable<T, std::void_t<decltype(std::declval<T>() == std::declval<T>())>>
+        : std::is_convertible<decltype(std::declval<T>() == std::declval<T>()), bool>
+        {
+        };
 
-    template <class T> constexpr bool is_equality_comparable_v = is_equality_comparable<T>::value;
+        template <class T> constexpr bool is_equality_comparable_v = is_equality_comparable<T>::value;
+    } // namespace details
 } // namespace GPIO
 
 #endif

--- a/include/JetsonGPIO/WaitResult.h
+++ b/include/JetsonGPIO/WaitResult.h
@@ -23,34 +23,31 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
 
-#include "JetsonGPIO/LazyString.h"
+#pragma once
+#ifndef WAIT_RESULT_H
+#define WAIT_RESULT_H
+
+#include <string>
 
 namespace GPIO
 {
-    LazyString::LazyString(const std::function<std::string(void)>& func) : buffer(), is_cached(false), func(func) {}
-
-    LazyString::LazyString(const std::string& str) : buffer(str), is_cached(true), func() {}
-
-    LazyString::LazyString(const char* str) : buffer(str == nullptr ? "" : str), is_cached(true), func() {}
-
-    LazyString::operator const char*() const { return this->operator()().c_str(); }
-
-    LazyString::operator std::string() const { return this->operator()(); }
-
-    const std::string& LazyString::operator()() const
+    class WaitResult
     {
-        Evaluate();
-        return buffer;
-    }
+    public:
+        WaitResult(const std::string& channel);
+        WaitResult(const WaitResult&) = default;
+        WaitResult(WaitResult&&) = default;
+        WaitResult& operator=(const WaitResult&) = default;
+        WaitResult& operator=(WaitResult&&) = default;
 
-    void LazyString::Evaluate() const
-    {
-        if (is_cached)
-            return;
+        inline const std::string& channel() const { return _channel; }
+        bool is_event_detected() const;
+        inline operator bool() const { return is_event_detected(); }
 
-        if (func != nullptr)
-            buffer = func();
+    private:
+        std::string _channel;
+    };
 
-        is_cached = true;
-    }
 } // namespace GPIO
+
+#endif

--- a/include/private/GPIOEvent.h
+++ b/include/private/GPIOEvent.h
@@ -23,10 +23,11 @@ DEALINGS IN THE SOFTWARE.
 */
 
 #pragma once
-#ifndef GPIO_EVENT
-#define GPIO_EVENT
+#ifndef GPIO_EVENT_H
+#define GPIO_EVENT_H
 
-#include "JetsonGPIO.h"
+#include "JetsonGPIO/Callback.h"
+#include "JetsonGPIO/PublicEnums.h"
 #include <map>
 #include <string>
 
@@ -70,4 +71,4 @@ namespace GPIO
     void _event_cleanup(int gpio, const std::string& gpio_name);
 } // namespace GPIO
 
-#endif /* GPIO_EVENT */
+#endif

--- a/include/private/GPIOPinData.h
+++ b/include/private/GPIOPinData.h
@@ -32,7 +32,7 @@ DEALINGS IN THE SOFTWARE.
 #include <string>
 #include <vector>
 
-#include "JetsonGPIO.h"
+#include "JetsonGPIO/PublicEnums.h"
 #include "private/Model.h"
 
 namespace GPIO

--- a/include/private/PinDefinition.h
+++ b/include/private/PinDefinition.h
@@ -26,7 +26,7 @@ DEALINGS IN THE SOFTWARE.
 #ifndef PIN_DEFINITION_H
 #define PIN_DEFINITION_H
 
-#include "JetsonGPIO.h"
+#include "JetsonGPIO/PublicEnums.h"
 #include "private/DictionaryLike.h"
 #include "private/PythonFunctions.h"
 

--- a/src/Callback.cpp
+++ b/src/Callback.cpp
@@ -23,7 +23,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
 
-#include "JetsonGPIO.h"
+#include "JetsonGPIO/Callback.h"
 
 namespace GPIO
 {

--- a/src/GPIOEvent.cpp
+++ b/src/GPIOEvent.cpp
@@ -43,7 +43,6 @@ DEALINGS IN THE SOFTWARE.
 #include <thread>
 #include <vector>
 
-#include "JetsonGPIO.h"
 
 constexpr size_t MAX_EPOLL_EVENTS = 20;
 

--- a/src/GPIOPinData.cpp
+++ b/src/GPIOPinData.cpp
@@ -36,7 +36,7 @@ DEALINGS IN THE SOFTWARE.
 #include <tuple>
 #include <vector>
 
-#include "JetsonGPIO.h"
+#include "JetsonGPIO/PublicEnums.h"
 #include "private/ExceptionHandling.h"
 #include "private/GPIOPinData.h"
 #include "private/ModelUtility.h"

--- a/src/PWM.cpp
+++ b/src/PWM.cpp
@@ -26,6 +26,7 @@ DEALINGS IN THE SOFTWARE.
 #include <iostream>
 
 #include "JetsonGPIO.h"
+#include "JetsonGPIO/PWM.h"
 #include "private/ExceptionHandling.h"
 #include "private/MainModule.h"
 

--- a/src/PWM.cpp
+++ b/src/PWM.cpp
@@ -26,7 +26,6 @@ DEALINGS IN THE SOFTWARE.
 #include <iostream>
 
 #include "JetsonGPIO.h"
-#include "JetsonGPIO/PWM.h"
 #include "private/ExceptionHandling.h"
 #include "private/MainModule.h"
 

--- a/src/WaitResult.cpp
+++ b/src/WaitResult.cpp
@@ -23,7 +23,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
 
-#include "JetsonGPIO.h"
+#include "JetsonGPIO/WaitResult.h"
 #include "private/PythonFunctions.h"
 
 namespace GPIO


### PR DESCRIPTION
- divide `JetsonGPIO.h` file into multiple header files for the readability
-  minor namespace change