### PR TITLE
Missing #include and namespace designator 

### DIFF
--- a/include/JetsonGPIO/LazyString.h
+++ b/include/JetsonGPIO/LazyString.h
@@ -61,7 +61,7 @@ namespace GPIO
     {
         template <class T>
         constexpr bool is_string =
-            std::is_constructible<LazyString, T>::value && !std::is_same<std::decay_t<T>, nullptr_t>::value;
+            std::is_constructible<LazyString, T>::value && !std::is_same<std::decay_t<T>, std::nullptr_t>::value;
 
         template <class T1, class T2>
         constexpr bool is_lazy_string_comparision = is_string<T1>&& is_string<T2> &&

--- a/src/GPIOEvent.cpp
+++ b/src/GPIOEvent.cpp
@@ -42,6 +42,7 @@ DEALINGS IN THE SOFTWARE.
 #include <mutex>
 #include <thread>
 #include <vector>
+#include <memory>
 
 
 constexpr size_t MAX_EPOLL_EVENTS = 20;


### PR DESCRIPTION
Missing `#include <memory>` for `std::shared_ptr` and namespace designator for `std::nullptr_t` 