### PR TITLE
Solved sporadic crash when setmode is called multiple times

### DIFF
--- a/src/JetsonGPIO.cpp
+++ b/src/JetsonGPIO.cpp
@@ -65,8 +65,11 @@ namespace GPIO
             if (global()._gpio_mode != NumberingModes::None && mode != global()._gpio_mode)
                 throw std::runtime_error("A different mode has already been set!");
 
-            global()._channel_data = global()._channel_data_by_mode.at(mode);
-            global()._gpio_mode = mode;
+            if (global()._gpio_mode == NumberingModes::None)
+            {
+                global()._channel_data = global()._channel_data_by_mode.at(mode);
+                global()._gpio_mode = mode;
+            }
         }
         catch (std::exception& e)
         {


### PR DESCRIPTION
I had the problem, that sometimes if I wanted to set an output the software crashed with the exception "Channel 26 is invalid".
I tracked down the problem to the [is_in()](https://github.com/pjueon/JetsonGPIO/blob/d935854455e4a00496bfccce90caa29079daf855/include/private/PythonFunctions.h#L60) function in PythonFunctions.h. The moment the exception is thrown, the is_in() functions received an empty dictionary. I tested this by printing the size of the dictionary in the is_in() function.

I'm not sure why this happens. Because the _channel_data dictionary is only updated on startup and on every setmode(), I added a check to change the dictionary only once. This should not be a problem in my opinion, as you cannot update the mode once it has been set.

After the change, the problem no longer occurred. However, since it occurred only sporadically, I cannot say with 100% certainty that it is solved.