### PR TITLE
fix: nullptr_t is part of std

### DIFF
--- a/include/JetsonGPIO/Callback.h
+++ b/include/JetsonGPIO/Callback.h
@@ -99,7 +99,7 @@ namespace GPIO
             NoArgCallback(const NoArgCallback&) = default;
             NoArgCallback(NoArgCallback&&) = default;
 
-            template <class T, class = std::enable_if_t<!std::is_same<std::decay_t<T>, nullptr_t>::value &&
+            template <class T, class = std::enable_if_t<!std::is_same<std::decay_t<T>, std::nullptr_t>::value &&
                                                         std::is_constructible<func_t, T&&>::value>>
             NoArgCallback(T&& function)
             : function(std::forward<T>(function)), comparer(comparer_impl::Compare<std::decay_t<T>>)


### PR DESCRIPTION
Fixing following issue
```
In file included from /home/multiflash/multiflash2/cmake-build-debug-jetson/_deps/jetsongpio-src/include/private/GPIOEvent.h:29:
/home/multiflash/multiflash2/cmake-build-debug-jetson/_deps/jetsongpio-src/include/JetsonGPIO/Callback.h:102:88: error: unknown type name 'nullptr_t'; did you mean 'std::nullptr_t'?
            template <class T, class = std::enable_if_t<!std::is_same<std::decay_t<T>, nullptr_t>::value &&
                                                                                       ^~~~~~~~~
                                                                                       std::nullptr_t
/usr/bin/../lib/gcc/aarch64-linux-gnu/7.5.0/../../../../include/aarch64-linux-gnu/c++/7.5.0/bits/c++config.h:235:29: note: 'std::nullptr_t' declared here
  typedef decltype(nullptr)     nullptr_t;
```