### PR TITLE
add multiple arguments support for setup

### DIFF
--- a/docs/library_api.md
+++ b/docs/library_api.md
@@ -74,6 +74,18 @@ It is also possible to specify an initial value for the output channel:
 GPIO::setup(channel, GPIO::OUT, GPIO::HIGH);
 ```
 
+Setting up multiple channels is also supported. 
+```cpp
+// setup multiple channels as input
+GPIO::setup({chan1, chan2}, GPIO::IN);
+
+// setup multiple output channels. The initial value(GPIO::HIGH) is optional. 
+GPIO::setup({chan3, chan4, chan5}, GPIO::OUT, GPIO::HIGH);
+
+// setup multiple output channels with multiple initial values. The number of channels and number of values must be equal. 
+GPIO::setup({chan6, chan7}, GPIO::OUT, {GPIO::HIGH, GPIO::LOW});
+```
+
 
 #### 5. Input
 

--- a/include/JetsonGPIO.h
+++ b/include/JetsonGPIO.h
@@ -64,6 +64,12 @@ namespace GPIO
        @initial must be HIGH, LOW or -1 and is only valid when direction is OUT  */
     void setup(const std::string& channel, Directions direction, int initial = -1);
     void setup(int channel, Directions direction, int initial = -1);
+    void setup(const std::vector<std::string>& channels, Directions direction, int initial = -1);
+    void setup(const std::vector<int>& channels, Directions direction, int initial = -1);
+    void setup(const std::initializer_list<int>& channels, Directions direction, int initial = -1);
+    void setup(const std::vector<std::string>& channels, Directions direction, const std::vector<int>& initials);
+    void setup(const std::vector<int>& channels, Directions direction, const std::vector<int>& initials); 
+    void setup(const std::initializer_list<int>& channels, Directions direction, const std::vector<int>& initials); 
 
     /* Function used to cleanup channels at the end of the program.
        If no channel is provided, all channels are cleaned */

--- a/include/JetsonGPIO/TypeTraits.h
+++ b/include/JetsonGPIO/TypeTraits.h
@@ -80,7 +80,7 @@ namespace GPIO
         template <class T> constexpr bool is_equality_comparable_v = is_equality_comparable<T>::value;
 
         // is_iterable
-        template <class T, typename = void> struct is_iterable : std::false_type
+        template <class T, class = void> struct is_iterable : std::false_type
         {
         };
 
@@ -97,6 +97,18 @@ namespace GPIO
         };
 
         template <class T> constexpr bool is_iterable_v = is_iterable<T>::value;
+
+
+        template<class T, class = void> struct value_type;
+        
+        template<class T, std::size_t N> struct value_type<T[N]> { using type = T; };
+        
+        template<class T> struct value_type<T, std::void_t<typename T::value_type>>
+        {
+            using type = typename T::value_type;
+        };
+
+        template<class T> using value_type_t = typename value_type<T>::type;
 
     } // namespace details
 } // namespace GPIO

--- a/src/JetsonGPIO.cpp
+++ b/src/JetsonGPIO.cpp
@@ -132,6 +132,47 @@ namespace GPIO
 
     void setup(int channel, Directions direction, int initial) { setup(std::to_string(channel), direction, initial); }
 
+    void setup(const std::vector<std::string>& channels, Directions direction, int initial)
+    {
+        for (const auto& channel : channels)
+            setup(channel, direction, initial);
+    }
+
+    void setup(const std::vector<int>& channels, Directions direction, int initial)
+    {
+        for (const auto& channel : channels)
+            setup(channel, direction, initial);
+    }    
+
+    void setup(const std::initializer_list<int>& channels, Directions direction, int initial)
+    {
+        setup(std::vector<int>(channels), direction, initial);
+    }
+
+    void setup(const std::vector<std::string>& channels, Directions direction, const std::vector<int>& initials)
+    {
+        if (direction == Directions::OUT && channels.size() != initials.size())
+            throw std::runtime_error(format("Number of values (%d) != number of channels (%d)", initials.size(), channels.size()));
+
+        for (std::size_t i = 0; i < channels.size(); i++)
+            setup(channels[i], direction, initials[i]);    
+    }
+
+    void setup(const std::vector<int>& channels, Directions direction, const std::vector<int>& initials)
+    {
+        std::vector<std::string> _channels(channels.size());
+        std::transform(channels.begin(), channels.end(), _channels.begin(),
+                       [](int value) { return std::to_string(value); });
+
+        setup(_channels, direction, initials);
+    }
+
+    void setup(const std::initializer_list<int>& channels, Directions direction, const std::vector<int>& initials)
+    {
+        setup(std::vector<int>(channels), direction, initials);
+    }
+
+
     // clean all channels if no channel param provided
     void cleanup()
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(_unit_test_targets
     "test_lower"
     "test_none"
     "test_is_iterable"
+    "test_value_type"
     )
 
 

--- a/tests/test_all_apis.cpp
+++ b/tests/test_all_apis.cpp
@@ -346,7 +346,7 @@ private:
         GPIO::cleanup();
     }
 
-    void test_setup_all()
+    void test_setup_all0()
     {
         GPIO::setmode(GPIO::BOARD);
         for (auto pin : all_board_pins)
@@ -357,6 +357,47 @@ private:
         }
         GPIO::cleanup();
     }
+
+    void test_setup_all1()
+    {
+        GPIO::setmode(GPIO::BOARD);
+        std::vector<int> pins{};
+        pins.reserve(all_board_pins.size());
+
+        for (auto pin : all_board_pins)
+        {
+            if (is_in(pin, pin_data.unimplemented_pins))
+                continue;
+
+            pins.emplace_back(pin);
+        }
+
+        GPIO::setup(pins, GPIO::IN);
+        GPIO::cleanup();
+    }
+
+    void test_setup_multiple_outputs0()
+    {
+        GPIO::setmode(GPIO::BOARD);
+        GPIO::setup({pin_data.out_a, pin_data.out_b}, GPIO::OUT);
+        GPIO::cleanup();
+    }
+
+    void test_setup_multiple_outputs1()
+    {
+        GPIO::setmode(GPIO::BOARD);
+        GPIO::setup({pin_data.out_a, pin_data.out_b}, GPIO::OUT, {GPIO::HIGH, GPIO::LOW});
+        GPIO::cleanup();
+    }
+
+
+    void test_setup_multiple_outputs2()
+    {
+        GPIO::setmode(GPIO::BOARD);
+        GPIO::setup({std::to_string(pin_data.out_a), std::to_string(pin_data.out_b)}, GPIO::OUT, {GPIO::LOW, GPIO::HIGH});
+        GPIO::cleanup();
+    }
+
 
     void test_cleanup_one()
     {
@@ -727,7 +768,11 @@ private:
         ADD_TEST(test_setup_one_out_high);
         ADD_TEST(test_setup_one_out_low);
         ADD_TEST(test_setup_one_in);
-        ADD_TEST(test_setup_all);
+        ADD_TEST(test_setup_all0);
+        ADD_TEST(test_setup_all1);
+        ADD_TEST(test_setup_multiple_outputs0);
+        ADD_TEST(test_setup_multiple_outputs1);
+        ADD_TEST(test_setup_multiple_outputs2);
         ADD_TEST(test_cleanup_one);
         ADD_TEST(test_cleanup_all);
         ADD_TEST(test_input);

--- a/tests/unit-tests/test_value_type.cpp
+++ b/tests/unit-tests/test_value_type.cpp
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2019-2023, Jueon Park(pjueon) <bluegbgb@gmail.com>.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#include "private/TestUtility.h"
+#include "JetsonGPIO/TypeTraits.h"
+#include <vector>
+#include <string>
+#include <set>
+#include <list>
+#include <type_traits>
+
+namespace
+{
+    void Vector()
+    {
+        using T = std::vector<double>;
+        using expected = double;
+        using actual = GPIO::details::value_type_t<T>;
+
+        assert::is_true(std::is_same<expected, actual>::value);
+    }
+
+    void Set()
+    {
+        using T = std::set<std::string>;
+        using expected = std::string;
+        using actual = GPIO::details::value_type_t<T>;
+
+        assert::is_true(std::is_same<expected, actual>::value);
+    }
+
+    void InitializerList()
+    {
+        using T = std::initializer_list<unsigned int>;
+        using expected = unsigned int;
+        using actual = GPIO::details::value_type_t<T>;
+
+        assert::is_true(std::is_same<expected, actual>::value);
+    }
+
+    void RawArray()
+    {
+        using T = int[3];
+        using expected = int;
+        using actual = GPIO::details::value_type_t<T>;
+
+        assert::is_true(std::is_same<expected, actual>::value);
+    }
+
+    void List()
+    {
+        using T = std::set<float>;
+        using expected = float;
+        using actual = GPIO::details::value_type_t<T>;
+
+        assert::is_true(std::is_same<expected, actual>::value);
+    }
+}
+
+int main()
+{
+    TestSuit suit{};
+
+#define TEST(NAME) {#NAME, NAME}
+    suit.add(TEST(Vector));
+    suit.add(TEST(Set));
+    suit.add(TEST(InitializerList));
+    suit.add(TEST(RawArray));
+    suit.add(TEST(List));
+#undef TEST
+
+    return suit.run();
+}


### PR DESCRIPTION
- related to #54
- add multiple channels & single/none initial value support for `setup`
- add multiple channels & multiple initial values support for `setup` (output only)