### PR TITLE
Remove unnecessary overload of GPIO::cleanup()

### DIFF
--- a/include/JetsonGPIO.h
+++ b/include/JetsonGPIO.h
@@ -79,7 +79,6 @@ namespace GPIO
     void cleanup(const std::vector<int>& channels);
     void cleanup(const std::vector<std::string>& channels);
     void cleanup(const std::initializer_list<int>& channels);
-    void cleanup(const std::initializer_list<std::string>& channels);
 
     /* Function used to return the current value of the specified channel.
        @returns either HIGH or LOW */

--- a/src/JetsonGPIO.cpp
+++ b/src/JetsonGPIO.cpp
@@ -225,7 +225,6 @@ namespace GPIO
     }
 
     void cleanup(const std::initializer_list<int>& channels) { cleanup(std::vector<int>(channels)); }
-    void cleanup(const std::initializer_list<std::string>& channels) { cleanup(std::vector<std::string>(channels)); }
 
     int input(const std::string& channel)
     {


### PR DESCRIPTION
- Unlike `std::initializer_list<int>`, `std::initializer_list<std::string>` has only one overload candidate: `std::vector<std::string>`