### PR TITLE
Update sysfs_prefixes

### DIFF
--- a/src/GPIOPinData.cpp
+++ b/src/GPIOPinData.cpp
@@ -674,7 +674,7 @@ namespace GPIO
             map<string, string> gpio_chip_ngpio{};
             map<string, string> pwm_dirs{};
 
-            vector<string> sysfs_prefixes = {"/sys/devices/", "/sys/devices/platform/"};
+            vector<string> sysfs_prefixes = {"/sys/devices/", "/sys/devices/platform/", "/sys/bus/platform/devices/"};
 
             // Get the gpiochip offsets
             set<string> gpio_chip_names{};


### PR DESCRIPTION
Update sysfs_prefixes for kernel 5.15

See: NVIDIA/jetson-gpio@e9f417a40fd2347182ed82af6a3a7b837db9df64